### PR TITLE
consistent rule ids

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ requirements:
 
 lint:
 	python -m pylint atakama
-	black atakama
+	black atakama tests
 
 test:
 	PYTHONPATH=. python -mpytest --cov atakama -v tests

--- a/atakama/rule_engine.py
+++ b/atakama/rule_engine.py
@@ -1,7 +1,6 @@
 """Atakama keyserver ruleset library"""
 import abc
 import hashlib
-import inspect
 import json
 from collections import defaultdict
 from dataclasses import dataclass
@@ -184,7 +183,11 @@ class RuleSet(List[RulePlugin]):
 
     def to_list(self) -> List[Dict]:
         lst = []
-        for ent in self:
+        for (
+            ent
+        ) in (
+            self
+        ):  # pylint: disable=not-an-iterable  https://github.com/PyCQA/pylint/issues/2568
             lst.append(ent.to_dict())
         return lst
 
@@ -214,7 +217,11 @@ class RuleTree(List[RuleSet]):
 
     def to_list(self) -> List[List[Dict]]:
         lst = []
-        for ent in self:
+        for (
+            ent
+        ) in (
+            self
+        ):  # pylint: disable=not-an-iterable  https://github.com/PyCQA/pylint/issues/2568
             lst.append(ent.to_list())
         return lst
 

--- a/atakama/rule_engine.py
+++ b/atakama/rule_engine.py
@@ -119,11 +119,19 @@ class RulePlugin(Plugin):
 class RuleIdGenerator:
     """Manage unique rule id generation."""
 
+    __autodoc__ = False
+
     def __init__(self):
         self._seen = defaultdict(lambda: 0)
         self._rule_seq = 0
 
     def inject_rule_id(self, ent: dict):
+        """
+        Modify the supplied dictionary to add a rule_id, but only if a rule_id is not present.
+
+        Keeps track of rule id's and ensures uniqueness, while trying to maintain consistency.
+        """
+
         self._rule_seq += 1
         rule_id = ent.get("rule_id")
         if not rule_id:

--- a/atakama/rule_engine.py
+++ b/atakama/rule_engine.py
@@ -128,7 +128,6 @@ class RuleIdGenerator:
 
     def __init__(self):
         self._seen = defaultdict(lambda: 0)
-        self._rule_seq = 0
 
     def inject_rule_id(self, ent: dict):
         """
@@ -137,17 +136,17 @@ class RuleIdGenerator:
         Keeps track of rule id's and ensures uniqueness, while trying to maintain consistency.
         """
 
-        self._rule_seq += 1
         rule_id = ent.get("rule_id")
         if not rule_id:
             ent_data = json.dumps(ent, sort_keys=True, separators=(",", ":"))
             ent_hash = hashlib.md5(ent_data.encode("utf8")).hexdigest()
             # if the hash is enough, use it, that way it's relocatable and still consistent
             if ent_hash in self._seen:
+                self._seen[ent_hash] += 1
                 # otherwise append a sequence
-                ent_hash += "." + str(self._rule_seq)
-            rule_id = ent["rule_id"] = ent_hash
-        self._seen[rule_id] += 1
+                ent_hash += "." + str(self._seen[ent_hash])
+            ent["rule_id"] = ent_hash
+        self._seen[ent["rule_id"]] += 1
 
 
 class RuleSet(List[RulePlugin]):

--- a/atakama/rule_engine.py
+++ b/atakama/rule_engine.py
@@ -183,11 +183,8 @@ class RuleSet(List[RulePlugin]):
 
     def to_list(self) -> List[Dict]:
         lst = []
-        for (
-            ent
-        ) in (
-            self
-        ):  # pylint: disable=not-an-iterable  https://github.com/PyCQA/pylint/issues/2568
+        # https://github.com/PyCQA/pylint/issues/2568
+        for ent in self:  # pylint: disable=not-an-iterable
             lst.append(ent.to_dict())
         return lst
 
@@ -217,11 +214,7 @@ class RuleTree(List[RuleSet]):
 
     def to_list(self) -> List[List[Dict]]:
         lst = []
-        for (
-            ent
-        ) in (
-            self
-        ):  # pylint: disable=not-an-iterable  https://github.com/PyCQA/pylint/issues/2568
+        for ent in self:  # pylint: disable=not-an-iterable
             lst.append(ent.to_list())
         return lst
 

--- a/docs/atakama_rule_engine.md
+++ b/docs/atakama_rule_engine.md
@@ -33,6 +33,11 @@ If no tree is available, will return None, so the caller can determine the defau
 
 
 
+## RuleIdGenerator(object)
+Manage unique rule id generation.
+
+
+
 ## RulePlugin(Plugin)
 
 Base class for key server approval rule handlers.
@@ -41,6 +46,9 @@ When a key server receives a request, rules are consulted for approval.
 
 Each rule receives its configuration from the policy file,
 not the atakama config, like other plugins.
+
+In addition to standard arguments from the policy, file a unique
+`rule_id` is injected, if not present.
 
 
 

--- a/docs/atakama_rule_engine.md
+++ b/docs/atakama_rule_engine.md
@@ -33,11 +33,6 @@ If no tree is available, will return None, so the caller can determine the defau
 
 
 
-## RuleIdGenerator(object)
-Manage unique rule id generation.
-
-
-
 ## RulePlugin(Plugin)
 
 Base class for key server approval rule handlers.

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def long_description():
 
 setup(
     name="atakama",
-    version="1.4.0",
+    version="1.5.0",
     description="Atakama sdk",
     packages=["atakama"],
     long_description=long_description(),

--- a/tests/test_name_match_detector.py
+++ b/tests/test_name_match_detector.py
@@ -1,19 +1,29 @@
 from example.name_match import NameMatchDetector
 
+
 def test_regex():
-    detector = NameMatchDetector({"type": " Regex", "pattern": "(?i).*\\.(pdf|doc|docx)$"})
+    detector = NameMatchDetector(
+        {"type": " Regex", "pattern": "(?i).*\\.(pdf|doc|docx)$"}
+    )
     assert detector.needs_encryption(r"C:\Users\Documents\Documentation\document.doc")
     assert detector.needs_encryption(r"C:\Users\Documents\Documentation\document.DoC")
     assert detector.needs_encryption(r"D:\Downloads\secrets.pdf")
     assert not detector.needs_encryption(r"D:\Downloads\secrets.xls")
     assert not detector.needs_encryption(r"C:\Users\Downloads\confidential.docm")
 
-    detector = NameMatchDetector({"type": " Regex", "pattern": "(?i).*\\.(pdf|doc|docx)$", "invert": "true"})
-    assert not detector.needs_encryption(r"C:\Users\Documents\Documentation\document.doc")
-    assert not detector.needs_encryption(r"C:\Users\Documents\Documentation\document.DoC")
+    detector = NameMatchDetector(
+        {"type": " Regex", "pattern": "(?i).*\\.(pdf|doc|docx)$", "invert": "true"}
+    )
+    assert not detector.needs_encryption(
+        r"C:\Users\Documents\Documentation\document.doc"
+    )
+    assert not detector.needs_encryption(
+        r"C:\Users\Documents\Documentation\document.DoC"
+    )
     assert not detector.needs_encryption(r"D:\Downloads\secrets.pdf")
     assert detector.needs_encryption(r"D:\Downloads\secrets.xls")
     assert detector.needs_encryption(r"C:\Users\Downloads\confidential.docm")
+
 
 def test_glob():
     detector = NameMatchDetector({"type": "gloB", "pattern": "*.pdf"})
@@ -25,6 +35,7 @@ def test_glob():
     assert not detector.needs_encryption(r"C:\Downloads\secRetS.pdf")
     assert not detector.needs_encryption(r"D:\Downloads\secrets.pdf")
     assert detector.needs_encryption(r"F:\Top Secret.docx")
+
 
 def test_true():
     detector = NameMatchDetector({"type": " * "})

--- a/tests/test_rulesets.py
+++ b/tests/test_rulesets.py
@@ -306,3 +306,17 @@ def test_rule_id_loads(tmp_path):
     )
     assert re.map[RequestType.DECRYPT][2][0].args["rule_id"] == "my_id"
     assert len({rs[0].args["rule_id"] for rs in re.map[RequestType.DECRYPT]}) == 3
+
+    expect = {
+        RequestType.DECRYPT.value: [
+            [{"rule": "example_loader", "rule_id": "74f7d0d4f50171df97b517416ac46df2"}],
+            [
+                {
+                    "rule": "example_loader",
+                    "rule_id": "74f7d0d4f50171df97b517416ac46df2.2",
+                }
+            ],
+            [{"rule": "example_loader", "rule_id": "my_id"}],
+        ]
+    }
+    assert re.to_dict() == expect

--- a/tests/test_rulesets.py
+++ b/tests/test_rulesets.py
@@ -295,18 +295,6 @@ def test_rule_id_loads(tmp_path):
 
     re = RuleEngine.from_yml_file(rule_yml)
 
-    # unique with same hash
-    assert (
-        re.map[RequestType.DECRYPT][0][0].args["rule_id"]
-        == "74f7d0d4f50171df97b517416ac46df2"
-    )
-    assert (
-        re.map[RequestType.DECRYPT][1][0].args["rule_id"]
-        == "74f7d0d4f50171df97b517416ac46df2.2"
-    )
-    assert re.map[RequestType.DECRYPT][2][0].args["rule_id"] == "my_id"
-    assert len({rs[0].args["rule_id"] for rs in re.map[RequestType.DECRYPT]}) == 3
-
     expect = {
         RequestType.DECRYPT.value: [
             [{"rule": "example_loader", "rule_id": "74f7d0d4f50171df97b517416ac46df2"}],


### PR DESCRIPTION
adds a "rule_id" that gets passed to each rule

the id is derived from a hash of the rule, so it's consistent even if the rule moves around

multiple rules with the same hash are disambiguated by appending a sequence number