### PR TITLE
add a per-object unique id to the approval request

### DIFF
--- a/atakama/rule_engine.py
+++ b/atakama/rule_engine.py
@@ -51,9 +51,11 @@ class ApprovalRequest:
     device_id: bytes
     """Requesting device uuid"""
     profile: ProfileInfo
-    """"""
+    """User profile information"""
     auth_meta: List[MetaInfo]
     """Authenticated metadata associated with the encrypted data.   Typically a path to a file."""
+    cryptographic_id: bytes
+    """"Unique cryptographic object id.  Can be used as a file UUID."""
 
 
 class RulePlugin(Plugin):

--- a/atakama/rule_engine.py
+++ b/atakama/rule_engine.py
@@ -46,16 +46,22 @@ class MetaInfo:
 
 @dataclass
 class ApprovalRequest:
+    """
+    Rule engine plugins receive this object upon request.
+
+    Members:
+     - request_type: RequestType
+     - device_id: bytes - *uuid for the device*
+     - profile: ProfileInfo - *user profile uuid and verification words*
+     - auth_meta: List[MetaInfo] - *typically a path to a file*
+     - cryptographic_id: bytes - *uuid for the file or data object**
+    """
+
     request_type: RequestType
-    """Request type"""
     device_id: bytes
-    """Requesting device uuid"""
     profile: ProfileInfo
-    """User profile information"""
     auth_meta: List[MetaInfo]
-    """Authenticated metadata associated with the encrypted data.   Typically a path to a file."""
     cryptographic_id: bytes
-    """"Unique cryptographic object id.  Can be used as a file UUID."""
 
 
 class RulePlugin(Plugin):

--- a/docs/atakama_rule_engine.md
+++ b/docs/atakama_rule_engine.md
@@ -4,7 +4,7 @@ Atakama keyserver ruleset library
 
 [(view source)](https://github.com/AtakamaLLC/atakama_sdk/blob/master/atakama/rule_engine.py)
 ## ApprovalRequest(object)
-ApprovalRequest(request_type: atakama.rule_engine.RequestType, device_id: bytes, profile: atakama.rule_engine.ProfileInfo, auth_meta: List[atakama.rule_engine.MetaInfo])
+ApprovalRequest(request_type: atakama.rule_engine.RequestType, device_id: bytes, profile: atakama.rule_engine.ProfileInfo, auth_meta: List[atakama.rule_engine.MetaInfo], cryptographic_id: bytes)
 
 
 

--- a/docs/atakama_rule_engine.md
+++ b/docs/atakama_rule_engine.md
@@ -4,7 +4,16 @@ Atakama keyserver ruleset library
 
 [(view source)](https://github.com/AtakamaLLC/atakama_sdk/blob/master/atakama/rule_engine.py)
 ## ApprovalRequest(object)
-ApprovalRequest(request_type: atakama.rule_engine.RequestType, device_id: bytes, profile: atakama.rule_engine.ProfileInfo, auth_meta: List[atakama.rule_engine.MetaInfo], cryptographic_id: bytes)
+
+Rule engine plugins receive this object upon request.
+
+Members:
+ - request_type: RequestType
+ - device_id: bytes - *uuid for the device*
+ - profile: ProfileInfo - *user profile uuid and verification words*
+ - auth_meta: List[MetaInfo] - *typically a path to a file*
+ - cryptographic_id: bytes - *uuid for the file or data object**
+
 
 
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def long_description():
 
 setup(
     name="atakama",
-    version="1.5.0",
+    version="1.6.0",
     description="Atakama sdk",
     packages=["atakama"],
     long_description=long_description(),

--- a/tests/test_rulesets.py
+++ b/tests/test_rulesets.py
@@ -48,6 +48,7 @@ class TestApprovalRequest(ApprovalRequest):
             device_id=device_id,
             profile=profile,
             auth_meta=auth_meta,
+            cryptographic_id=b"cid",
         )
 
 


### PR DESCRIPTION
That way a throttle-per-file can work.  This id is cannot be malleable.